### PR TITLE
smartcontract hardhat-console log cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,14 @@ The codebase consists of a wrapper written in typescript which is responsible fo
 ```bash
 yarn install 
 ```
+### Set up secrets file
+
+In root directory create file ./.secrets.json:
+```
+{
+    "testPrivKey": "0x123123123123123123123123123123123123"
+}
+```
 
 ### Compiling and running the tests
 

--- a/contracts/commons/PriceFeed.sol
+++ b/contracts/commons/PriceFeed.sol
@@ -5,7 +5,6 @@ pragma experimental ABIEncoderV2;
 
 
 import './IPriceFeed.sol';
-import 'hardhat/console.sol';
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "./PriceVerifier.sol";
 

--- a/contracts/commons/PriceVerifier.sol
+++ b/contracts/commons/PriceVerifier.sol
@@ -5,7 +5,6 @@ pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import './PriceModel.sol';
-import 'hardhat/console.sol';
 
 contract PriceVerifier is PriceModel {
     using ECDSA for bytes32;

--- a/contracts/message-based/PriceAware.sol
+++ b/contracts/message-based/PriceAware.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.2;
 
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
-import "hardhat/console.sol";
 
 contract PriceAware is Ownable  {
   using ECDSA for bytes32;

--- a/contracts/message-based/PriceAwareUpgradeable.sol
+++ b/contracts/message-based/PriceAwareUpgradeable.sol
@@ -24,7 +24,6 @@ contract PriceAwareUpgradeable is OwnableUpgradeable {
         require(_trustedSigner != address(0));
         trustedSigner = _trustedSigner;
 
-        console.log('trustedSigner: ', trustedSigner);
 
         emit TrustedSignerChanged(trustedSigner);
     }

--- a/contracts/message-based/PriceAwareUpgradeable.sol
+++ b/contracts/message-based/PriceAwareUpgradeable.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.2;
 
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import "hardhat/console.sol";
 
 contract PriceAwareUpgradeable is OwnableUpgradeable {
     using ECDSA for bytes32;

--- a/contracts/message-based/PriceAwareV1.sol
+++ b/contracts/message-based/PriceAwareV1.sol
@@ -5,7 +5,6 @@ pragma solidity ^0.8.2;
 import "../commons/PriceVerifier.sol";
 import "../commons/BytesLib.sol";
 import '../commons/PriceFeed.sol';
-import 'hardhat/console.sol';
 import "@openzeppelin/contracts/proxy/Proxy.sol";
 
 

--- a/contracts/storage-based/clearing/RedstoneCoreProxy.sol
+++ b/contracts/storage-based/clearing/RedstoneCoreProxy.sol
@@ -3,7 +3,6 @@
 pragma solidity ^0.8.2;
 
 import "../../commons/BytesLib.sol";
-import 'hardhat/console.sol';
 import '../../commons/PriceFeedWithClearing.sol';
 import "@openzeppelin/contracts/proxy/Proxy.sol";
 

--- a/contracts/storage-based/without-clearing/RedstoneCoreProxyWithoutClearing.sol
+++ b/contracts/storage-based/without-clearing/RedstoneCoreProxyWithoutClearing.sol
@@ -3,7 +3,6 @@
 pragma solidity ^0.8.2;
 
 import "../../commons/BytesLib.sol";
-import 'hardhat/console.sol';
 import '../../commons/PriceFeed.sol';
 import "@openzeppelin/contracts/proxy/Proxy.sol";
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -5,7 +5,7 @@ import "hardhat-deploy";
 const secrets = require("./.secret.json");
 
 export default {
-    solidity: "0.8.2",
+    solidity: "0.8.4",
     networks: {
         hardhat: {
             chainId: 7

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "ethers": "^5.4.4",
     "hardhat": "^2.6.0",
     "hardhat-gas-reporter": "^1.0.4",
-    "ts-node": "^10.2.0",
+    "ts-node": "^10.4.0",
     "typescript": "^4.3.5"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -169,10 +169,10 @@
   resolved "https://registry.yarnpkg.com/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz#33bf4b7b39c178821606f669bbc447a6a629786b"
   integrity sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==
 
-"@cspotcode/source-map-support@0.6.1":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.6.1.tgz#118511f316e2e87ee4294761868e254d3da47960"
-  integrity sha512-DX3Z+T5dt1ockmPdobJS/FAsQPW4V4SrWEhD2iYQT2Cb2tQsiMnYxrcUH9By/Z3B+v0S5LMBkQtV/XOBbpLEOg==
+"@cspotcode/source-map-support@0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz#4789840aa859e46d2f3173727ab707c66bf344f5"
+  integrity sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==
   dependencies:
     "@cspotcode/source-map-consumer" "0.8.0"
 
@@ -1115,9 +1115,9 @@
   integrity sha512-i/pOaOtcqDk4UqsrOv735uYyTbn6dvfiuVu5hstsgV6c4ZKUtu88/31zT2BzkCg+3JfcwOfgg2TtRKVKKZIGkQ==
 
 "@openzeppelin/contracts@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.1.0.tgz#baec89a7f5f73e3d8ea582a78f1980134b605375"
-  integrity sha512-TihZitscnaHNcZgXGj9zDLDyCqjziytB4tMCwXq0XimfWkAjBYyk5/pOsDbbwcavhlc79HhpTEpQcrMnPVa1mw==
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.3.3.tgz#ff6ee919fc2a1abaf72b22814bfb72ed129ec137"
+  integrity sha512-tDBopO1c98Yk7Cv/PZlHqrvtVjlgK5R4J6jxLwoO7qxK4xqOiZG+zSkIvGFpPZ0ikc3QOED3plgdqjgNTnBc7g==
 
 "@openzeppelin/test-helpers@^0.5.10":
   version "0.5.11"
@@ -10172,12 +10172,12 @@ ts-generator@^0.1.1:
     resolve "^1.8.1"
     ts-essentials "^1.0.0"
 
-ts-node@^10.2.0:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.2.0.tgz#f1e88249a00e26aa95e9a93c50f70241a8a1c4bb"
-  integrity sha512-FstYHtQz6isj8rBtYMN4bZdnXN1vq4HCbqn9vdNQcInRqtB86PePJQIxE6es0PhxKWhj2PHuwbG40H+bxkZPmg==
+ts-node@^10.4.0:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.4.0.tgz#680f88945885f4e6cf450e7f0d6223dd404895f7"
+  integrity sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==
   dependencies:
-    "@cspotcode/source-map-support" "0.6.1"
+    "@cspotcode/source-map-support" "0.7.0"
     "@tsconfig/node10" "^1.0.7"
     "@tsconfig/node12" "^1.0.7"
     "@tsconfig/node14" "^1.0.0"


### PR DESCRIPTION
Removed hardhat console log to allow using smartcontracts in other frameworks. 

Updated compiler to 0.8.4 to bypass compiling error in [reported issue at OZ](https://github.com/OpenZeppelin/openzeppelin-contracts/issues/2979)

Added instruction about secrets.json.

Suggest to further look into and fix Solidity compiling warnings.
